### PR TITLE
Add IP to public machine struct

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -65,6 +65,7 @@ type Machine struct {
 	Fingerprint       string                 `json:"fingerprint"`
 	Hostname          string                 `json:"hostname"`
 	Platform          string                 `json:"platform"`
+	IP                string                 `json:"ip"`
 	Cores             int                    `json:"cores"`
 	RequireHeartbeat  bool                   `json:"requireHeartbeat"`
 	HeartbeatStatus   HeartbeatStatusCode    `json:"heartbeatStatus"`


### PR DESCRIPTION
Supersedes #15. Adds the IP property to the public `Machine` struct, but does not implement functionality to set a machine's IP attribute during `license.Activate()`. This allows the IP property to be accessible via a machine file.

One possibility for setting the IP could be:

```go
func (l *License) Activate(fingerprint string, components ...Component) (*Machine, error) {
	client := NewClient()
	hostname, _ := os.Hostname()
	conn, _ := net.Dial("udp", "keygen.sh:80") // this doesn't actually hit the network
	defer conn.Close()

	params := &Machine{
		Fingerprint: fingerprint,
		Hostname:    hostname,
		Platform:    runtime.GOOS + "/" + runtime.GOARCH,
		IP:          conn.LocalAddr().String(),
		Cores:       runtime.NumCPU(),
		LicenseID:   l.ID,
		components:  components,
	}

	machine := &Machine{}
	if _, err := client.Post("machines", params, machine); err != nil {
		return nil, err
	}

	return machine, nil
}
```

But that risks not using the _right_ IP, so it may be best to leave this to the end user somehow.