### PR TITLE
doc: add installation section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 Package [`keygen`](https://pkg.go.dev/github.com/keygen-sh/keygen-go/v2) allows Go programs to
 license and remotely update themselves using the [keygen.sh](https://keygen.sh) service.
 
+## Installing
+
+```
+go get github.com/keygen-sh/keygen-go/v2
+```
+
 ## Config
 
 ### keygen.Account


### PR DESCRIPTION
Yesterday I spent a few hours debugging why my integration wasn't working properly, turned out that I installed `github.com/keygen-sh/keygen-go` instead of the v2 package. 

So I'm adding the `Installing` section in the README so other developers don't have the same problem as me.