### PR TITLE
v3: add `context.Context` to all public functions that rely on networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Keygen Go SDK
 
-[![godoc reference](https://godoc.org/github.com/keygen-sh/keygen-go/v2?status.png)](https://godoc.org/github.com/keygen-sh/keygen-go/v2)
+[![godoc reference](https://godoc.org/github.com/keygen-sh/keygen-go/v3?status.png)](https://godoc.org/github.com/keygen-sh/keygen-go/v3)
 [![CI](https://github.com/keygen-sh/keygen-go/actions/workflows/test.yml/badge.svg)](https://github.com/keygen-sh/keygen-go/actions)
 
-Package [`keygen`](https://pkg.go.dev/github.com/keygen-sh/keygen-go/v2) allows Go programs to
+Package [`keygen`](https://pkg.go.dev/github.com/keygen-sh/keygen-go/v3) allows Go programs to
 license and remotely update themselves using the [keygen.sh](https://keygen.sh) service.
 
 ## Installing
 
 ```
-go get github.com/keygen-sh/keygen-go/v2
+go get github.com/keygen-sh/keygen-go/v3
 ```
 
 ## Config
@@ -168,7 +168,7 @@ package main
 
 import (
   "github.com/denisbrodbeck/machineid"
-  "github.com/keygen-sh/keygen-go/v2"
+  "github.com/keygen-sh/keygen-go/v3"
 )
 
 func main() {
@@ -210,7 +210,7 @@ Check for an upgrade and automatically replace the current binary with the newes
 ```go
 package main
 
-import "github.com/keygen-sh/keygen-go/v2"
+import "github.com/keygen-sh/keygen-go/v3"
 
 // The current version of the program
 const CurrentVersion = "1.0.0"
@@ -264,7 +264,7 @@ package main
 
 import (
   "github.com/google/uuid"
-  "github.com/keygen-sh/keygen-go/v2"
+  "github.com/keygen-sh/keygen-go/v3"
 )
 
 func main() {
@@ -345,7 +345,7 @@ Requires that `keygen.PublicKey` is set.
 ```go
 package main
 
-import "github.com/keygen-sh/keygen-go/v2"
+import "github.com/keygen-sh/keygen-go/v3"
 
 func main() {
   keygen.PublicKey = "YOUR_KEYGEN_PUBLIC_KEY"
@@ -395,7 +395,7 @@ Requires that `keygen.PublicKey` is set.
 ```go
 package main
 
-import "github.com/keygen-sh/keygen-go/v2"
+import "github.com/keygen-sh/keygen-go/v3"
 
 func main() {
   keygen.PublicKey = "YOUR_KEYGEN_PUBLIC_KEY"
@@ -430,7 +430,7 @@ import (
   "log"
   "net/http"
 
-  "github.com/keygen-sh/keygen-go/v2"
+  "github.com/keygen-sh/keygen-go/v3"
 )
 
 func main() {
@@ -463,7 +463,7 @@ key does not exist. You can handle this accordingly.
 ```go
 package main
 
-import "github.com/keygen-sh/keygen-go/v2"
+import "github.com/keygen-sh/keygen-go/v3"
 
 func getLicense() (*keygen.License, error) {
   keygen.LicenseKey = promptForLicenseKey()
@@ -503,7 +503,7 @@ token does not exist or has expired. You can handle this accordingly.
 ```go
 package main
 
-import "github.com/keygen-sh/keygen-go/v2"
+import "github.com/keygen-sh/keygen-go/v3"
 
 func getLicense() (*keygen.License, error) {
   keygen.Token = promptForLicenseToken()
@@ -544,7 +544,7 @@ determine how long to wait before retrying a request.
 ```go
 package main
 
-import "github.com/keygen-sh/keygen-go/v2"
+import "github.com/keygen-sh/keygen-go/v3"
 
 func validate() (*keygen.License, error) {
   license, err := keygen.Validate()
@@ -590,7 +590,7 @@ package main
 
 import (
   "github.com/hashicorp/go-retryablehttp"
-  "github.com/keygen-sh/keygen-go/v2"
+  "github.com/keygen-sh/keygen-go/v3"
 )
 
 func main() {
@@ -625,7 +625,7 @@ package main
 import (
   "testing"
 
-  "github.com/keygen-sh/keygen-go/v2"
+  "github.com/keygen-sh/keygen-go/v3"
   "gopkg.in/h2non/gock.v1"
 )
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ It will return a `License` object as well as any validation errors that occur. T
 object can be used to perform additional actions, such as `license.Activate(fingerprint)`.
 
 ```go
-license, err := keygen.Validate(context.Background(), fingerprint)
+ctx := context.Background()
+license, err := keygen.Validate(ctx, fingerprint)
 switch {
 case err == keygen.ErrLicenseNotActivated:
   panic("license is not activated!")

--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package keygen
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -111,8 +112,8 @@ func NewClientWithOptions(options *ClientOptions) *Client {
 }
 
 // Post is a convenience helper for performing POST requests.
-func (c *Client) Post(path string, params interface{}, model interface{}) (*Response, error) {
-	req, err := c.new(http.MethodPost, path, params)
+func (c *Client) Post(ctx context.Context, path string, params interface{}, model interface{}) (*Response, error) {
+	req, err := c.new(ctx, http.MethodPost, path, params)
 	if err != nil {
 		return nil, err
 	}
@@ -121,8 +122,8 @@ func (c *Client) Post(path string, params interface{}, model interface{}) (*Resp
 }
 
 // Get is a convenience helper for performing GET requests.
-func (c *Client) Get(path string, params interface{}, model interface{}) (*Response, error) {
-	req, err := c.new(http.MethodGet, path, params)
+func (c *Client) Get(ctx context.Context, path string, params interface{}, model interface{}) (*Response, error) {
+	req, err := c.new(ctx, http.MethodGet, path, params)
 	if err != nil {
 		return nil, err
 	}
@@ -131,8 +132,8 @@ func (c *Client) Get(path string, params interface{}, model interface{}) (*Respo
 }
 
 // Put is a convenience helper for performing PUT requests.
-func (c *Client) Put(path string, params interface{}, model interface{}) (*Response, error) {
-	req, err := c.new(http.MethodPut, path, params)
+func (c *Client) Put(ctx context.Context, path string, params interface{}, model interface{}) (*Response, error) {
+	req, err := c.new(ctx, http.MethodPut, path, params)
 	if err != nil {
 		return nil, err
 	}
@@ -141,8 +142,8 @@ func (c *Client) Put(path string, params interface{}, model interface{}) (*Respo
 }
 
 // Patch is a convenience helper for performing PATCH requests.
-func (c *Client) Patch(path string, params interface{}, model interface{}) (*Response, error) {
-	req, err := c.new(http.MethodPatch, path, params)
+func (c *Client) Patch(ctx context.Context, path string, params interface{}, model interface{}) (*Response, error) {
+	req, err := c.new(ctx, http.MethodPatch, path, params)
 	if err != nil {
 		return nil, err
 	}
@@ -151,8 +152,8 @@ func (c *Client) Patch(path string, params interface{}, model interface{}) (*Res
 }
 
 // Delete is a convenience helper for performing DELETE requests.
-func (c *Client) Delete(path string, params interface{}, model interface{}) (*Response, error) {
-	req, err := c.new(http.MethodDelete, path, params)
+func (c *Client) Delete(ctx context.Context, path string, params interface{}, model interface{}) (*Response, error) {
+	req, err := c.new(ctx, http.MethodDelete, path, params)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +161,7 @@ func (c *Client) Delete(path string, params interface{}, model interface{}) (*Re
 	return c.send(req, model)
 }
 
-func (c *Client) new(method string, path string, params interface{}) (*http.Request, error) {
+func (c *Client) new(ctx context.Context, method string, path string, params interface{}) (*http.Request, error) {
 	var url string
 
 	if c.APIVersion == "" {
@@ -260,7 +261,7 @@ func (c *Client) new(method string, path string, params interface{}) (*http.Requ
 	req.Header.Add("Accept", jsonapi.ContentType)
 	req.Header.Add("User-Agent", ua)
 
-	return req, nil
+	return req.WithContext(ctx), nil
 }
 
 func (c *Client) send(req *http.Request, model interface{}) (*Response, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/keygen-sh/keygen-go/v2
+module github.com/keygen-sh/keygen-go/v3
 
 go 1.17
 

--- a/process.go
+++ b/process.go
@@ -1,6 +1,7 @@
 package keygen
 
 import (
+	"context"
 	"time"
 
 	"github.com/keygen-sh/jsonapi-go"
@@ -106,18 +107,18 @@ func (p *Processes) SetData(to func(target interface{}) error) error {
 
 // Kill deletes the current Process. An error will be returned if the process
 // deletion fails.
-func (p *Process) Kill() error {
+func (p *Process) Kill(ctx context.Context) error {
 	client := NewClient()
 
-	if _, err := client.Delete("processes/"+p.ID, nil, nil); err != nil {
+	if _, err := client.Delete(ctx, "processes/"+p.ID, nil, nil); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (p *Process) monitor() error {
-	if err := p.ping(); err != nil {
+func (p *Process) monitor(ctx context.Context) error {
+	if err := p.ping(ctx); err != nil {
 		return err
 	}
 
@@ -125,7 +126,7 @@ func (p *Process) monitor() error {
 		t := (time.Duration(p.Interval) * time.Second) - (30 * time.Second)
 
 		for range time.Tick(t) {
-			if err := p.ping(); err != nil {
+			if err := p.ping(ctx); err != nil {
 				panic(err)
 			}
 		}
@@ -134,10 +135,10 @@ func (p *Process) monitor() error {
 	return nil
 }
 
-func (p *Process) ping() error {
+func (p *Process) ping(ctx context.Context) error {
 	client := NewClient()
 
-	if _, err := client.Post("processes/"+p.ID+"/actions/ping", nil, p); err != nil {
+	if _, err := client.Post(ctx, "processes/"+p.ID+"/actions/ping", nil, p); err != nil {
 		return err
 	}
 

--- a/release.go
+++ b/release.go
@@ -2,6 +2,7 @@ package keygen
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"encoding/base64"
 	"encoding/hex"
@@ -48,8 +49,8 @@ func (r *Release) SetData(to func(target interface{}) error) error {
 }
 
 // Install performs an update of the current executable to the new Release.
-func (r *Release) Install() error {
-	artifact, err := r.artifact()
+func (r *Release) Install(ctx context.Context) error {
+	artifact, err := r.artifact(ctx)
 	if err != nil {
 		return err
 	}
@@ -91,7 +92,7 @@ func (r *Release) Install() error {
 	return nil
 }
 
-func (r *Release) artifact() (*Artifact, error) {
+func (r *Release) artifact(ctx context.Context) (*Artifact, error) {
 	client := NewClient()
 	artifact := &Artifact{}
 
@@ -100,7 +101,7 @@ func (r *Release) artifact() (*Artifact, error) {
 		return nil, err
 	}
 
-	res, err := client.Get("releases/"+r.ID+"/artifacts/"+filename, nil, artifact)
+	res, err := client.Get(ctx, "releases/"+r.ID+"/artifacts/"+filename, nil, artifact)
 	if err != nil {
 		return nil, err
 	}

--- a/upgrade.go
+++ b/upgrade.go
@@ -1,5 +1,7 @@
 package keygen
 
+import "context"
+
 type UpgradeOptions struct {
 	// CurrentVersion is the current version of the program. This will be used by
 	// Keygen to determine if an upgrade is available.
@@ -50,7 +52,7 @@ type UpgradeOptions struct {
 
 // Upgrade checks if an upgrade is available for the provided version. Returns a
 // Release and any errors that occurred, e.g. ErrUpgradeNotAvailable.
-func Upgrade(options UpgradeOptions) (*Release, error) {
+func Upgrade(ctx context.Context, options UpgradeOptions) (*Release, error) {
 	if options.PublicKey == PublicKey {
 		panic("You MUST use a personal public key. This MUST NOT be your Keygen account's public key.")
 	}
@@ -75,7 +77,7 @@ func Upgrade(options UpgradeOptions) (*Release, error) {
 	params := querystring{Product: options.Product, Package: options.Package, Constraint: options.Constraint, Channel: options.Channel}
 	release := &Release{}
 
-	if _, err := client.Get("releases/"+options.CurrentVersion+"/upgrade", params, release); err != nil {
+	if _, err := client.Get(ctx, "releases/"+options.CurrentVersion+"/upgrade", params, release); err != nil {
 		switch err.(type) {
 		case *NotFoundError:
 			return nil, ErrUpgradeNotAvailable

--- a/validate.go
+++ b/validate.go
@@ -1,5 +1,7 @@
 package keygen
 
+import "context"
+
 type ValidationCode string
 
 const (
@@ -89,15 +91,15 @@ type ValidationResult struct {
 // and the rest are optional component fingerprints. It returns a License, and
 // an error if the license is invalid, e.g. ErrLicenseNotActivated or
 // ErrLicenseExpired.
-func Validate(fingerprints ...string) (*License, error) {
+func Validate(ctx context.Context, fingerprints ...string) (*License, error) {
 	client := NewClient()
 	license := &License{}
 
-	if _, err := client.Get("me", nil, license); err != nil {
+	if _, err := client.Get(ctx, "me", nil, license); err != nil {
 		return nil, err
 	}
 
-	if err := license.Validate(fingerprints...); err != nil {
+	if err := license.Validate(ctx, fingerprints...); err != nil {
 		return license, err
 	}
 


### PR DESCRIPTION
This PR adds the `context.Context` to all public functions that rely on networking. This enables users to create deadlines, cancel operations, and allow tracing to be added via the `Context` object.

This is related to the issue #14 