### PR TITLE
fix: robust handling of whitespace in license files

### DIFF
--- a/license_file.go
+++ b/license_file.go
@@ -99,11 +99,12 @@ func (lic *LicenseFile) Decrypt(key string) (*LicenseFileDataset, error) {
 }
 
 func (lic *LicenseFile) certificate() (*certificate, error) {
-	payload := lic.Certificate
+	payload := strings.TrimSpace(lic.Certificate)
 
 	// Remove header and footer
-	payload = strings.TrimPrefix(payload, "-----BEGIN LICENSE FILE-----\n")
-	payload = strings.TrimSuffix(payload, "-----END LICENSE FILE-----\n")
+	payload = strings.TrimPrefix(payload, "-----BEGIN LICENSE FILE-----")
+	payload = strings.TrimSuffix(payload, "-----END LICENSE FILE-----")
+	payload = strings.TrimSpace(payload)
 
 	// Decode
 	dec, err := base64.StdEncoding.DecodeString(payload)


### PR DESCRIPTION
When the license file is copied from the Keygen UI it does not contain the new line character. If this is copied directly into a secrets manager, one gets invalid license errors.

This removes the reliance on whitespace characters from the logic for parsing license files.

